### PR TITLE
dd "upernet_r50_512x1024_40k_cityscapes to algolib":

### DIFF
--- a/algolib/runner/mmseg.yaml
+++ b/algolib/runner/mmseg.yaml
@@ -28,6 +28,7 @@ models:
   - ocrnet_hr48_512x512_160k_ade20k
   - isanet_r101-d8_512x512_160k_ade20k
   - dmnet_r101-d8_512x512_160k_ade20k
+  - upernet_r50_512x1024_40k_cityscapes
   # 注：以下三个模型存在问题，详见：https://jira.sensetime.com/browse/PARROTSXQ-7694?filter=-2
   # - upernet_swin_tiny_patch4_window7_512x512_160k_ade20k_pretrain_224x224_1K
   # - upernet_swin_small_patch4_window7_512x512_160k_ade20k_pretrain_224x224_1K

--- a/algolib/runner/train.sh
+++ b/algolib/runner/train.sh
@@ -91,6 +91,10 @@ case $MODEL_NAME in
     "dmnet_r101-d8_512x512_160k_ade20k")
         FULL_MODEL="dmnet/dmnet_r101-d8_512x512_160k_ade20k"
         ;;
+    "upernet_r50_512x1024_40k_cityscapes")
+        FULL_MODEL="upernet/upernet_r50_512x1024_40k_cityscapes"
+        ;;
+
     # 注：以下三个模型存在相同的问题，详见：https://jira.sensetime.com/browse/PARROTSXQ-7694?filter=-2
     # "upernet_swin_tiny_patch4_window7_512x512_160k_ade20k_pretrain_224x224_1K")
     #     FULL_MODEL="swin/upernet_swin_tiny_patch4_window7_512x512_160k_ade20k_pretrain_224x224_1K"

--- a/configs/_base_/datasets/cityscapes.py
+++ b/configs/_base_/datasets/cityscapes.py
@@ -1,6 +1,6 @@
 # dataset settings
 dataset_type = 'CityscapesDataset'
-data_root = 'data/cityscapes/'
+data_root = '/mnt/lustre/share_data/PAT/datasets/mmseg/cityscapes/'
 img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 crop_size = (512, 1024)

--- a/mmseg/__init__.py
+++ b/mmseg/__init__.py
@@ -7,7 +7,7 @@ from packaging.version import parse
 from .version import __version__, version_info
 
 MMCV_MIN = '1.3.13'
-MMCV_MAX = '1.4.0'
+MMCV_MAX = '1.5.3'
 
 
 def digit_version(version_str: str, length: int = 4):


### PR DESCRIPTION
功能抽象: 添加upernet_r50_512x1024_40k_cityscapes
类别: 其他
背景: 0.23 版本预研 基于MLU290硬件，完成10个模型预研
测试:
* 测试: NA
  - [ ] 已有单元测试
  - [ ] 新增单元测试
  - [ ] 修改单元测试
  - [ ] 每日构建
  - [ ] 每周构建
* 报错优化建议: 无 

